### PR TITLE
Fix displaying solutions

### DIFF
--- a/evarist/controllers/workflow.py
+++ b/evarist/controllers/workflow.py
@@ -246,10 +246,26 @@ def problem(problem_set_slug,prob_id):
         if edit_solution_form.delete_solution.data:
             solution.delete()
         else:
-            solution.text=edit_solution_form.edited_solution.data
-            solution.date=datetime.datetime.utcnow()
-            solution.changed_and_not_checked=True
-            solution.save()
+            # file=request.files[edit_solution_form.edit_image.name]
+            # image_url=solution.image_url
+            # if file:
+            #     upload_result = upload(file)
+            #     image_url=upload_result['url'] 
+            new_solution=Solution(text=edit_solution_form.edited_solution.data,
+                            author=g.user,
+                            problem=problem,
+                            problem_set=problem_set)
+            new_solution.save()
+            events.solution_written(new_solution)
+
+            # solution.text=edit_solution_form.edited_solution.data
+            # solution.date=datetime.datetime.utcnow()
+            # solution.changed_and_not_checked=True
+            # solution.save()
+
+
+
+
         return redirect(url_for('.problem', 
                                 problem_set_slug=problem_set_slug,
                                 prob_id=problem['id']))
@@ -351,10 +367,22 @@ def my_solutions():
         if edit_solution_form.delete_solution.data:
             solution.delete()
         else:
-            solution.text=edit_solution_form.edited_solution.data
-            solution.date=datetime.datetime.utcnow()
-            solution.changed_and_not_checked=True
-            solution.save()
+            # file=request.files[edit_solution_form.edit_image.name]
+            # image_url=solution.image_url
+            # if file:
+            #     upload_result = upload(file)
+            #     image_url=upload_result['url'] 
+            new_solution=Solution(text=edit_solution_form.edited_solution.data,
+                            author=g.user,
+                            problem=solution.problem,
+                            problem_set=solution.problem_set)
+            new_solution.save()
+            events.solution_written(new_solution)
+
+            # solution.text=edit_solution_form.edited_solution.data
+            # solution.date=datetime.datetime.utcnow()
+            # solution.changed_and_not_checked=True
+            # solution.save()
         return redirect(url_for('.my_solutions'))
     # trigger_flash_error(edit_solution_form,'workflow.my_solutions')
 

--- a/evarist/controllers/workflow.py
+++ b/evarist/controllers/workflow.py
@@ -246,15 +246,18 @@ def problem(problem_set_slug,prob_id):
         if edit_solution_form.delete_solution.data:
             solution.delete()
         else:
-            # file=request.files[edit_solution_form.edit_image.name]
-            # image_url=solution.image_url
-            # if file:
-            #     upload_result = upload(file)
-            #     image_url=upload_result['url'] 
+            file=request.files[edit_solution_form.edit_image.name]
+            if edit_solution_form.use_old_image.data:
+                image_url=solution.image_url
+            else: image_url=None
+            if file:
+                upload_result = upload(file)
+                image_url=upload_result['url'] 
             new_solution=Solution(text=edit_solution_form.edited_solution.data,
                             author=g.user,
                             problem=problem,
-                            problem_set=problem_set)
+                            problem_set=problem_set,
+                            image_url=image_url)
             new_solution.save()
             events.solution_written(new_solution)
 
@@ -367,15 +370,18 @@ def my_solutions():
         if edit_solution_form.delete_solution.data:
             solution.delete()
         else:
-            # file=request.files[edit_solution_form.edit_image.name]
-            # image_url=solution.image_url
-            # if file:
-            #     upload_result = upload(file)
-            #     image_url=upload_result['url'] 
+            file=request.files[edit_solution_form.edit_image.name]
+            if edit_solution_form.use_old_image.data:
+                image_url=solution.image_url
+            else: image_url=None
+            if file:
+                upload_result = upload(file)
+                image_url=upload_result['url'] 
             new_solution=Solution(text=edit_solution_form.edited_solution.data,
                             author=g.user,
                             problem=solution.problem,
-                            problem_set=solution.problem_set)
+                            problem_set=solution.problem_set,
+                            image_url=image_url)
             new_solution.save()
             events.solution_written(new_solution)
 

--- a/evarist/forms.py
+++ b/evarist/forms.py
@@ -42,8 +42,17 @@ class SolutionForm(Form):
         return result
 
 class EditSolutionForm(Form):
-    edited_solution = TextField('edited_solution', validators=[Required()])
+    use_old_image=BooleanField('use_old_image')
+    edit_image = FileField('edit_image')
+    edited_solution = TextField('edited_solution')
     delete_solution=BooleanField('delete_solution')
+    def validate(self):
+        result=True
+        if not Form.validate(self):
+            return False
+        if not (self.edit_image.data or self.edited_solution.data):
+            return False
+        return result
 
 class SignUpForm(Form):
     email = TextField('email', validators=[Required(), Email()])

--- a/evarist/models/mongoengine_models.py
+++ b/evarist/models/mongoengine_models.py
@@ -139,6 +139,8 @@ class Solution(Comment):
     users_upvoted=db.ListField(db.ReferenceField('User'))
     users_downvoted=db.ListField(db.ReferenceField('User'))
 
+    # I made this thing only for editing solutions, which 
+    # has been replaced by writing new solutions. Soon I ll delete it.
     changed_and_not_checked=db.BooleanField(default=False)
 
 

--- a/evarist/templates/check.html
+++ b/evarist/templates/check.html
@@ -51,7 +51,7 @@
 
             <!-- vote form -->
             <div class="col-md-4 col-md-offset-2">
-            {%if g.user not in (  solution['users_upvoted']|list + solution['users_downvoted_']|list )%}
+            {%if g.user not in (  solution['users_upvoted']|list + solution['users_downvoted']|list )%}
               <form action="{{request.path}}?sol_id={{solution['id']}}" method="post">
                 {{ vote_form.hidden_tag() }}
                 {{ form_macros.vote_for_solution_form() }}

--- a/evarist/templates/macros/forms.html
+++ b/evarist/templates/macros/forms.html
@@ -1,9 +1,25 @@
+{% macro solution_form(name_of_textarea, name_of_the_button) -%}
+  <div class="form-group" >
+    <!-- <label for="feedback_to_solution">  <strong> Комментировать: </strong> </label> -->
+    <textarea class="form-control" rows="8"  name='{{name_of_textarea}}'></textarea>
+    <input type="file" name="image">
+  </div>
+  <button type="submit" class="btn btn-default"><!-- Отправить -->{{name_of_the_button}}</button>
+{%- endmacro %}
+
 {% macro edit_solution_form(solution) -%}
   <div class="form-group">
     <em>Обратите внимание на то, что исправленное решение - это еще одно новое решение, и существующее решение не удаляется.</em>
+    <br>
     <label for="edit_text">Исправьте решение здесь: </label>
     <textarea class="form-control" rows="8"  name='edited_solution'>{{solution.text}}  
     </textarea>
+    <input type="file" name="edit_image">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" name='use_old_image'> использовать ту же картинку
+      </label>
+    </div>
 
     <div class="checkbox" style='background-color:red'>
       <label>
@@ -52,12 +68,4 @@
   <button type="submit" class="btn btn-default"><!-- Отправить -->{{name_of_the_button}}</button>
 {%- endmacro %}
 
-{% macro solution_form(name_of_textarea, name_of_the_button) -%}
-  <div class="form-group" >
-    <!-- <label for="feedback_to_solution">  <strong> Комментировать: </strong> </label> -->
-    <textarea class="form-control" rows="8"  name='{{name_of_textarea}}'></textarea>
-    <input type="file" name="image">
-  </div>
-  <button type="submit" class="btn btn-default"><!-- Отправить -->{{name_of_the_button}}</button>
-{%- endmacro %}
 

--- a/evarist/templates/macros/forms.html
+++ b/evarist/templates/macros/forms.html
@@ -1,9 +1,10 @@
 {% macro edit_solution_form(solution) -%}
   <div class="form-group">
+    <em>Обратите внимание на то, что исправленное решение - это еще одно новое решение, и существующее решение не удаляется.</em>
     <label for="edit_text">Исправьте решение здесь: </label>
     <textarea class="form-control" rows="8"  name='edited_solution'>{{solution.text}}  
     </textarea>
-    
+
     <div class="checkbox" style='background-color:red'>
       <label>
         <input type="checkbox" name='delete_solution'>удалить это решение, навсегда

--- a/evarist/templates/my_solutions.html
+++ b/evarist/templates/my_solutions.html
@@ -14,7 +14,7 @@
       <hr>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="col-md-8 col-md-offset-2">
       <p>Здесь вы можете смотреть, исправлять и комментировать  ваши решения.</p>
@@ -27,6 +27,7 @@
     <div class="col-md-6 col-md-offset-0">
       <h3>Непроверенные задачи:</h3>
       {%for solution in not_checked_solutions%}
+
           <!-- solutions text, and the name of problem set -->
           <div>
             <a href="/problem_sets/{{solution.problem_set['slug']}}">{{solution.problem_set['title']|safe}}</a>.

--- a/evarist/templates/my_solutions.html
+++ b/evarist/templates/my_solutions.html
@@ -46,7 +46,7 @@
             Исправить решение
           </button>
           <div class="collapse" id="collapse_Id_edit_{{loop.index}}">
-            <form action=" {{url_for('workflow.my_solutions', sol_id=solution.id)}}" method="post">
+            <form action=" {{url_for('workflow.my_solutions', sol_id=solution.id)}}" method="post" enctype="multipart/form-data">
               {{ edit_solution_form.hidden_tag() }}
               {{form_macros.edit_solution_form(solution)}}
             </form>

--- a/evarist/templates/problem.html
+++ b/evarist/templates/problem.html
@@ -33,13 +33,13 @@
         </form>
 
       {% elif current_user_solutions%}
-        <button class="btn btn-xs btn-default" type="button" data-toggle="collapse" data-target="#solution_form" aria-expanded="false" aria-controls="solution_form">
+        <button class="btn btn-default" type="button" data-toggle="collapse" data-target="#solution_form" aria-expanded="false" aria-controls="solution_form">
           Отправить новое решение
         </button>
 
         <div class="collapse" id="solution_form">
 
-          <strong class="text-center"> Ваше решение </strong>
+          <strong class="text-center"> Написать решение: </strong>
           <!-- this is form for writing solution -->
           <form action=" {{url_for('workflow.problem', problem_set_slug=problem_set_slug, prob_id=problem['id'])}}" method="post" enctype="multipart/form-data">
             {{ solution_form.hidden_tag() }}

--- a/evarist/templates/problem.html
+++ b/evarist/templates/problem.html
@@ -93,7 +93,7 @@
               Исправить решение
             </button>
             <div class="collapse" id="solution_edit_{{loop.index}}">
-              <form action=" {{url_for('workflow.problem', problem_set_slug=problem_set_slug, prob_id=problem['id'], sol_id=current_solution.id)}}" method="post">
+              <form action=" {{url_for('workflow.problem', problem_set_slug=problem_set_slug, prob_id=problem['id'], sol_id=current_solution.id)}}" method="post" enctype="multipart/form-data">
                 {{ edit_solution_form.hidden_tag() }}
                 {{form_macros.edit_solution_form(current_solution)}}
               </form>


### PR DESCRIPTION
This is half of issue #7. Now user can submit multiple solutions, and when user edits it, new solution is created with edited text and picture. 

Left to do: add versions of solutions, so that we know which solution is edition of which.